### PR TITLE
up for discussion

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mocha": "^2.3.0",
     "promises-aplus-tests": "^2.1.1",
     "rollup": "^0.26.2",
+    "rollup-plugin-buble": "0.12.1",
     "uglify-js": "^2.6.0"
   }
 }

--- a/rollup.js
+++ b/rollup.js
@@ -1,0 +1,21 @@
+const rollup = require('rollup').rollup;
+const buble = require('rollup-plugin-buble');
+const fs = require('fs');
+
+rollup({
+        entry: './src/main.js',
+        plugins: [buble({
+            transforms: {
+                dangerousForOf: true
+            }
+        })]
+    })
+    .then(function(bundle) {
+        return bundle.write({
+            format: 'umd',
+            moduleName: 'creed',
+            dest: 'bundle.js'
+        });
+    })
+    .then(console.log)
+    .catch(console.trace)

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -65,7 +65,7 @@ export class Future extends Core {
 	}
 
 	// catch :: Promise e a -> (e -> b) -> Promise e b
-	_catch (r) {
+	['catch'] (r) {
 		const n = this.near()
 		return n === this ? then(void 0, r, n, new Future()) : n.catch(r)
 	}
@@ -200,7 +200,7 @@ class Fulfilled extends Core {
 		return typeof f === 'function' ? then(f, void 0, this, new Future()) : this
 	}
 
-	_catch () {
+	['catch'] () {
 		return this
 	}
 
@@ -259,7 +259,7 @@ class Rejected extends Core {
 		return typeof r === 'function' ? this.catch(r) : this
 	}
 
-	_catch (r) {
+	['catch'] (r) {
 		return then(void 0, r, this, new Future())
 	}
 
@@ -313,7 +313,7 @@ class Never extends Core {
 		return this
 	}
 
-	_catch () {
+	['catch'] () {
 		return this
 	}
 

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -65,7 +65,7 @@ export class Future extends Core {
 	}
 
 	// catch :: Promise e a -> (e -> b) -> Promise e b
-	catch (r) {
+	_catch (r) {
 		const n = this.near()
 		return n === this ? then(void 0, r, n, new Future()) : n.catch(r)
 	}
@@ -200,7 +200,7 @@ class Fulfilled extends Core {
 		return typeof f === 'function' ? then(f, void 0, this, new Future()) : this
 	}
 
-	catch () {
+	_catch () {
 		return this
 	}
 
@@ -259,7 +259,7 @@ class Rejected extends Core {
 		return typeof r === 'function' ? this.catch(r) : this
 	}
 
-	catch (r) {
+	_catch (r) {
 		return then(void 0, r, this, new Future())
 	}
 
@@ -313,7 +313,7 @@ class Never extends Core {
 		return this
 	}
 
-	catch () {
+	_catch () {
 		return this
 	}
 


### PR DESCRIPTION
@briancavalier As promised i would rollup + buble for creed... i thought i would use a PR to help illustrate buble's two issues with creed... 

- It doesnt like `for of` but we can get to work by passing in the option `dangerousForOf` more info [here](http://buble.surge.sh/guide/#dangerous-transforms)
- It didnt transform the `prototype.catch` methods to something like babel with the `_` for the function name
```js
Future.prototype.catch = function _catch(r) {
    var n = this.near();
    return n === this ? (0, _then3.default)(void 0, r, n, new Future()) : n.catch(r);
};
```

Thats where it was failing for you but was misleading in the line-numbers.. i renamed in case you want to jump into the branch to just to build it

Im thinking about opening an issue in buble for some type of reserved name support for function names as depicted above...

thoughts?

**edit**
i updated the `Promise.js` to use bracket notation with catch that way it doesnt create a function name... still should probably open a buble issue