### PR TITLE
Simplify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .idea/
 experiments/
 node_modules/
-build/
 coverage/

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "async"
   ],
   "scripts": {
-    "compile": "npm run compile-src",
-    "compile-src": "mkdirp build/src && buble -m -i src -o build/src --no modules",
-    "build-dist": "npm run compile && mkdirp dist && rollup -c",
+    "build-dist": "mkdirp dist && rollup -c",
     "build": "npm run build-dist && uglifyjs -c 'warnings=false' -m -o dist/creed.min.js -- dist/creed.js",
     "preversion": "npm run build",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --lines 100 --functions 100 coverage/coverage*.json",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,9 @@
+import buble from 'rollup-plugin-buble'
 const pkg = require('./package.json')
 
 export default {
-  entry: 'build/src/main.js',
+  entry: 'src/main.js',
+  plugins: [buble()],
   targets: [
     {
       format: 'umd',


### PR DESCRIPTION
Do away with the temp build dir in favor of using `rollup-plugin-buble`