### PR TITLE
Update ap to Fantasy Land 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,13 +473,13 @@ for the result.
 ```js
 import { resolve } from 'creed';
 
-resolve(x => x + 1)
-    .ap(resolve(123))
+resolve(123)
+    .ap(resolve(x => x + 1))
     .then(y => console.log(y)); //=> 124
 
-resolve(x => y => x+y)
-    .ap(resolve(1))
-    .ap(resolve(123))
+resolve(1)
+    .ap(resolve(123)
+        .ap(resolve(x => y => x + y)))
     .then(y => console.log(y)); //=> 124
 ```
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --lines 100 --functions 100 coverage/coverage*.json",
     "lint": "jsinspect src && eslint src",
     "pretest": "npm run lint",
-    "test": "istanbul cover node_modules/mocha/bin/_mocha",
+    "unit-test": "istanbul cover node_modules/mocha/bin/_mocha",
+    "test": "npm run unit-test",
     "posttest": "npm run test-aplus",
     "test-aplus": "promises-aplus-tests test/aplus.js --reporter dot"
   },

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -74,11 +74,10 @@ export class Future extends Core {
 		return n === this ? map(f, n, new Future()) : n.map(f)
 	}
 
-	// ap :: Promise e (a -> b) -> Promise e a -> Promise e b
-	ap (p) {
-		const n = this.near()
-		const pp = p.near()
-		return n === this ? this.chain(f => pp.map(f)) : n.ap(pp)
+	// ap :: Promise e a -> Promise e (a -> b) -> Promise e b
+	ap (pf) {
+		const npa = this.near()
+		return npa === this ? pf.chain(f => npa.map(f)) : npa.ap(pf)
 	}
 
 	// chain :: Promise e a -> (a -> Promise e b) -> Promise e b
@@ -206,8 +205,9 @@ class Fulfilled extends Core {
 		return map(f, this, new Future())
 	}
 
-	ap (p) {
-		return p.map(this.value)
+	ap (pf) {
+		const npf = pf.near()
+		return npf === pf ? pf.chain(f => this.map(f)) : this.ap(npf)
 	}
 
 	chain (f) {

--- a/test/ap-test.js
+++ b/test/ap-test.js
@@ -1,35 +1,35 @@
 import { describe, it } from 'mocha'
-import { fulfill } from '../src/main'
+import { delay } from '../src/main'
 import { assertSame } from './lib/test-util'
+
+const fulfill = x => delay(1, x)
 
 describe('ap', () => {
 	it('should satisfy identity', () => {
-		const v = fulfill({})
-		return assertSame(fulfill(x => x).ap(v), v)
+		const a = fulfill({})
+		return assertSame(a.ap(fulfill(x => x)), a)
 	})
 
 	it('should satisfy composition', () => {
 		const u = fulfill(x => 'u' + x)
 		const v = fulfill(x => 'v' + x)
-		const w = fulfill('w')
+		const a = fulfill('a')
 
 		return assertSame(
-			fulfill(f => g => x => f(g(x))).ap(u).ap(v).ap(w),
-			u.ap(v.ap(w))
+			a.ap(u.ap(v.map(f => g => x => f(g(x))))),
+			a.ap(u).ap(v)
 		)
 	})
 
 	it('should satisfy homomorphism', () => {
 		const f = x => x + 'f'
-		const x = 'x'
-		return assertSame(fulfill(f).ap(fulfill(x)), fulfill(f(x)))
+		const a = 'a'
+		return assertSame(fulfill(a).ap(fulfill(f)), fulfill(f(a)))
 	})
 
 	it('should satisfy interchange', () => {
-		const f = x => x + 'f'
-		const u = fulfill(f)
-		const y = 'y'
-
-		return assertSame(u.ap(fulfill(y)), fulfill(f => f(y)).ap(u))
+		const a = 'w'
+		const pf = fulfill(x => 'f' + x)
+		return assertSame(fulfill(a).ap(pf), pf.ap(fulfill(f => f(a))))
 	})
 })

--- a/test/future-test.js
+++ b/test/future-test.js
@@ -228,22 +228,22 @@ describe('future', () => {
 				const { resolve, promise } = future()
 				const p = fulfill(f)
 				const q = fulfill(1)
-				resolve(p)
-				return assertSame(p.ap(q), promise.ap(q))
+				resolve(q)
+				return assertSame(q.ap(p), promise.ap(p))
 			})
 
 			it('should be identity for reject', () => {
 				const { resolve, promise } = future()
-				const p = silenced(reject(f))
+				const p = silenced(reject(1))
 				resolve(p)
-				assert.strictEqual(p, promise.ap(fulfill(1)))
+				assert.strictEqual(p, promise.ap(fulfill(f)))
 			})
 
 			it('should be identity for never', () => {
 				const { resolve, promise } = future()
 				const p = never()
 				resolve(p)
-				return assert.strictEqual(p, promise.ap(fulfill(1)))
+				return assert.strictEqual(p, promise.ap(fulfill(f)))
 			})
 		})
 
@@ -414,15 +414,15 @@ describe('future', () => {
 				const { resolve, promise } = future()
 				const p = fulfill(f)
 				const q = fulfill(1)
-				const res = promise.ap(q)
-				resolve(p)
-				return assertSame(p.ap(q), res)
+				const res = promise.ap(p)
+				resolve(q)
+				return assertSame(q.ap(p), res)
 			})
 
 			it('should behave like rejected for reject', () => {
 				const { resolve, promise } = future()
-				const p = silenced(reject(f))
-				const res = promise.ap(fulfill(1))
+				const p = silenced(reject(1))
+				const res = promise.ap(fulfill(f))
 				resolve(p)
 				return assertSame(p, res)
 			})

--- a/test/reject-test.js
+++ b/test/reject-test.js
@@ -19,7 +19,7 @@ describe('reject', () => {
 	it('ap should be identity', () => {
 		const p = reject(assert.ifError)
 		silenceError(p)
-		assert.strictEqual(p, p.ap(fulfill(true)))
+		assert.strictEqual(p, p.ap(fulfill()))
 	})
 
 	it('chain should be identity', () => {


### PR DESCRIPTION
⚠️ BREAKING CHANGE ⚠️ 

This reverses the "argument" order for `ap` to be compliant with the same reversal in Fantasy Land 1.0.  This will force a 2.0.0 release.
