### PR TITLE
Add fantasy-land 2.0 compat namespaced methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ experiments/
 node_modules/
 coverage/
 perf/logs/
+.nyc_output/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/briancavalier/creed](https://badges.gitter.im/briancavalier/creed.svg)](https://gitter.im/briancavalier/creed?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Sophisticated and functionally-minded async with advanced features: coroutines, promises, ES2015 iterables, [fantasy-land](https://github.com/fantasyland/fantasy-land).
+Sophisticated and functionally-minded async with advanced features: coroutines, promises, ES2015 iterables, [fantasy-land](#fantasy-land).
 
 Creed simplifies async by letting you write coroutines using ES2015 generators and promises, and encourages functional programming via fantasy-land.  It also makes uncaught errors obvious by default, and supports other ES2015 features such as iterables.
 
@@ -451,7 +451,6 @@ reject(new Error('oops!'))
 
 ### .map :: Promise e a &rarr; (a &rarr; b) &rarr; Promise e b
 
-[Fantasy-land Functor](https://github.com/fantasyland/fantasy-land#functor).
 Transform a promise's value by applying a function.  The return
 value of the function will be used verbatim, even if it is a promise.
 Returns a new promise for the transformed value.
@@ -466,7 +465,6 @@ resolve(1)
 
 ### .ap :: Promise e (a &rarr; b) &rarr; Promise e a &rarr; Promise e b
 
-[Fantasy-land Apply](https://github.com/fantasyland/fantasy-land#apply).
 Apply a promised function to a promised value.  Returns a new promise
 for the result.
 
@@ -485,7 +483,6 @@ resolve(x => y => x+y)
 
 ### .chain :: Promise e a &rarr; (a &rarr; Promise e b) &rarr; Promise e b
 
-[Fantasy-land Chain](https://github.com/fantasyland/fantasy-land#chain).
 Sequence async actions.  When a promise fulfills, run another
 async action and return a promise for its result.
 
@@ -498,7 +495,6 @@ profileText.then(text => console.log(text)); //=> <user profile text>
 
 ### .concat :: Promise e a &rarr; Promise e a &rarr; Promise e a
 
-[Fantasy-land Semigroup](https://github.com/fantasyland/fantasy-land#semigroup).
 Returns a promise equivalent to the *earlier* of two promises. Preference is given to the callee promise in the case that both promises have already settled.
 
 ```js
@@ -760,3 +756,16 @@ let NativePromise = shim();
 // Create a creed promise
 Promise.resolve(123);
 ```
+
+## Fantasy Land
+
+Creed implements Fantasy Land 2.0:
+
+* [Functor](https://github.com/fantasyland/fantasy-land#functor)
+* [Apply](https://github.com/fantasyland/fantasy-land#apply)
+* [Applicative](https://github.com/fantasyland/fantasy-land#applicative)
+* [Chain](https://github.com/fantasyland/fantasy-land#chain)
+* [Monad](https://github.com/fantasyland/fantasy-land#monad)
+* [Semigroup](https://github.com/fantasyland/fantasy-land#semigroup)
+* [Monoid](https://github.com/fantasyland/fantasy-land#monoid)
+

--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "rollup": "^0.36.3",
     "rollup-plugin-buble": "^0.14.0",
     "uglify-js": "^2.7.3"
+  },
+  "dependencies": {
+    "fantasy-land": "^2.0.0"
   }
 }

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -13,6 +13,8 @@ import Race from './Race'
 import Merge from './Merge'
 import { resolveIterable, resultsArray } from './iterable'
 
+import fl from 'fantasy-land'
+
 const taskQueue = new TaskQueue()
 export { taskQueue }
 
@@ -25,7 +27,8 @@ const errorHandler = new ErrorHandler(makeEmitError(), e => {
 // ## Types
 // -------------------------------------------------------------
 
-// Internal base type to hold fantasy-land static constructors
+// Internal base type, provides fantasy-land namespace
+// and type representative
 class Core {
 	// empty :: Promise e a
 	static empty () {
@@ -35,6 +38,22 @@ class Core {
 	// of :: a -> Promise e a
 	static of (x) {
 		return fulfill(x)
+	}
+
+	[fl.map] (f) {
+		return this.map(f)
+	}
+
+	[fl.ap] (pf) {
+		return pf.ap(this)
+	}
+
+	[fl.chain] (f) {
+		return this.chain(f)
+	}
+
+	[fl.concat] (p) {
+		return this.concat(p)
 	}
 }
 

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -40,6 +40,14 @@ class Core {
 		return fulfill(x)
 	}
 
+	static [fl.empty] () {
+		return never()
+	}
+
+	static [fl.of] (x) {
+		return fulfill(x)
+	}
+
 	[fl.map] (f) {
 		return this.map(f)
 	}

--- a/test/fantasyland-laws-test.js
+++ b/test/fantasyland-laws-test.js
@@ -1,0 +1,65 @@
+import { describe, it } from 'mocha'
+import { fulfill, Promise } from '../src/main'
+import { assertSame } from './lib/test-util'
+import * as Functor from 'fantasy-land/laws/functor'
+import * as Chain from 'fantasy-land/laws/chain'
+import * as Apply from 'fantasy-land/laws/apply'
+import * as Applicative from 'fantasy-land/laws/applicative'
+import * as Semigroup from 'fantasy-land/laws/semigroup'
+import * as Monoid from 'fantasy-land/laws/monoid'
+
+describe('fantasyland laws', () => {
+  describe('functor', () => {
+    it('should satisfy identity', () => {
+      return Functor.identity(fulfill, assertSame, {})
+    })
+
+    it('should satisfy composition', () => {
+      const f = x => x + 'f'
+      const g = x => x + 'g'
+      return Functor.composition(fulfill, assertSame, f, g, {})
+    })
+  })
+
+  describe('apply', () => {
+    it('should satisfy composition', () => {
+      return Apply.composition(fulfill, assertSame, {})
+    })
+  })
+
+  describe('applicative', () => {
+    it('should satisfy identity', () => {
+      return Applicative.identity(Promise, assertSame, {})
+    })
+
+    it('should satisfy homomorphism', () => {
+      return Applicative.homomorphism(Promise, assertSame, {})
+    })
+
+    it('should satisfy interchange', () => {
+      return Applicative.interchange(Promise, assertSame, {})
+    })
+  })
+
+  describe('chain', () => {
+    it('should satisfy associativity', () => {
+      return Chain.associativity(fulfill, assertSame, {})
+    })
+  })
+
+  describe('semigroup', () => {
+    it('should satisfy associativity', () => {
+      return Semigroup.associativity(fulfill, assertSame, {})
+    })
+  })
+
+  describe('monoid', () => {
+    it('should satisfy rightIdentity', () => {
+      return Monoid.rightIdentity(Promise, assertSame, {})
+    })
+
+    it('should satisfy leftIdentity', () => {
+      return Monoid.leftIdentity(Promise, assertSame, {})
+    })
+  })
+})

--- a/test/fantasyland-laws-test.js
+++ b/test/fantasyland-laws-test.js
@@ -17,7 +17,7 @@ describe('fantasyland laws', () => {
     it('should satisfy composition', () => {
       const f = x => x + 'f'
       const g = x => x + 'g'
-      return Functor.composition(fulfill, assertSame, f, g, {})
+      return Functor.composition(fulfill, assertSame, f, g, 'x')
     })
   })
 

--- a/test/fantasyland-laws-test.js
+++ b/test/fantasyland-laws-test.js
@@ -7,6 +7,9 @@ import * as Apply from 'fantasy-land/laws/apply'
 import * as Applicative from 'fantasy-land/laws/applicative'
 import * as Semigroup from 'fantasy-land/laws/semigroup'
 import * as Monoid from 'fantasy-land/laws/monoid'
+import fl from 'fantasy-land'
+
+const id = x => x
 
 describe('fantasyland laws', () => {
   describe('functor', () => {
@@ -19,11 +22,19 @@ describe('fantasyland laws', () => {
       const g = x => x + 'g'
       return Functor.composition(fulfill, assertSame, f, g, 'x')
     })
+
+    it('should be covered', () => {
+      return fulfill()[fl.map](id)
+    })
   })
 
   describe('apply', () => {
     it('should satisfy composition', () => {
       return Apply.composition(fulfill, assertSame, {})
+    })
+
+    it('should be covered', () => {
+      return fulfill()[fl.ap](fulfill(id))
     })
   })
 
@@ -39,17 +50,29 @@ describe('fantasyland laws', () => {
     it('should satisfy interchange', () => {
       return Applicative.interchange(Promise, assertSame, {})
     })
+
+    it('should be covered', () => {
+      return Promise[fl.of](undefined)
+    })
   })
 
   describe('chain', () => {
     it('should satisfy associativity', () => {
       return Chain.associativity(fulfill, assertSame, {})
     })
+
+    it('should be covered', () => {
+      return fulfill()[fl.chain](fulfill)
+    })
   })
 
   describe('semigroup', () => {
     it('should satisfy associativity', () => {
       return Semigroup.associativity(fulfill, assertSame, {})
+    })
+
+    it('should be covered', () => {
+      return fulfill()[fl.concat](fulfill())
     })
   })
 
@@ -60,6 +83,10 @@ describe('fantasyland laws', () => {
 
     it('should satisfy leftIdentity', () => {
       return Monoid.leftIdentity(Promise, assertSame, {})
+    })
+
+    it('should be covered', () => {
+      return Promise[fl.empty]().concat(fulfill())
     })
   })
 })


### PR DESCRIPTION
This is not complete, but wanted to open it for discussion.  Inspired by @bergus' [comment here](https://github.com/briancavalier/creed/pull/85#issuecomment-255772461), it was trivial to add fantasy-land 2.0 compat, while maintaining back compat with current creed 1.x.

If we want to go this route, then there's a bit more todo:
- [x] Update docs
- ~~Merge #34, then update this PR to add namespaced bifunctor~~
- [x] Add tests to verify fl namespace methods.  Not sure the best way to do this, since we're already testing FL laws.  Perhaps this is the right time to use the [official fl laws test suite](https://github.com/fantasyland/fantasy-land/tree/master/laws)
