### PR TITLE
Add or(), deprecate concat()

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,17 +493,20 @@ let profileText = getUserProfileUrlFromDB(userId)
 profileText.then(text => console.log(text)); //=> <user profile text>
 ```
 
-### .concat :: Promise e a &rarr; Promise e a &rarr; Promise e a
+### .or :: Promise e a &rarr; Promise e a &rarr; Promise e a
+### (deprecated) .concat :: Promise e a &rarr; Promise e a &rarr; Promise e a
+
+**Note:** The name `concat` is deprecated, use `or` instead.
 
 Returns a promise equivalent to the *earlier* of two promises. Preference is given to the callee promise in the case that both promises have already settled.
 
 ```js
 import { delay, fulfill } from 'creed';
 
-delay(200, 'bar').concat(delay(100, 'foo'))
+delay(200, 'bar').or(delay(100, 'foo'))
     .then(x => console.log(x)); //=> 'foo'
 
-fulfill(123).concat(fulfill(456))
+fulfill(123).or(fulfill(456))
     .then(x => console.log(x)); //=> 123
 ```
 

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -63,6 +63,11 @@ class Core {
 	[fl.concat] (p) {
 		return this.concat(p)
 	}
+
+	// @deprecated The name concat is deprecated, use or() instead.
+	concat (b) {
+		return this.or(b)
+	}
 }
 
 // data Promise e a where
@@ -104,8 +109,8 @@ export class Future extends Core {
 	// ap :: Promise e (a -> b) -> Promise e a -> Promise e b
 	ap (p) {
 		const n = this.near()
-		const pp = p.near()
-		return n === this ? this.chain(f => pp.map(f)) : n.ap(pp)
+		const pn = p.near()
+		return n === this ? this.chain(f => pn.map(f)) : n.ap(pn)
 	}
 
 	// chain :: Promise e a -> (a -> Promise e b) -> Promise e b
@@ -114,15 +119,15 @@ export class Future extends Core {
 		return n === this ? chain(f, n, new Future()) : n.chain(f)
 	}
 
-	// concat :: Promise e a -> Promise e a -> Promise e a
-	concat (b) {
+	// or :: Promise e a -> Promise e a -> Promise e a
+	or (b) {
 		/* eslint complexity:[2,5] */
 		const n = this.near()
-		const bp = b.near()
+		const bn = b.near()
 
-		return isSettled(n) || isNever(bp) ? n
-			: isSettled(bp) || isNever(n) ? bp
-			: race([n, bp])
+		return isSettled(n) || isNever(bn) ? n
+			: isSettled(bn) || isNever(n) ? bn
+			: race([n, bn])
 	}
 
 	// toString :: Promise e a -> String
@@ -241,7 +246,7 @@ class Fulfilled extends Core {
 		return chain(f, this, new Future())
 	}
 
-	concat () {
+	or () {
 		return this
 	}
 
@@ -300,7 +305,7 @@ class Rejected extends Core {
 		return this
 	}
 
-	concat () {
+	or () {
 		return this
 	}
 
@@ -354,7 +359,7 @@ class Never extends Core {
 		return this
 	}
 
-	concat (b) {
+	or (b) {
 		return b
 	}
 

--- a/test/or-test.js
+++ b/test/or-test.js
@@ -7,49 +7,49 @@ import assert from 'assert'
 describe('concat', function () {
 	it('should be identity for fulfill', () => {
 		const p = fulfill()
-		assert.strictEqual(p, p.concat(fulfill()))
+		assert.strictEqual(p, p.or(fulfill()))
 	})
 
 	it('should be identity for reject', () => {
 		const p = reject()
 		silenceError(p)
-		assert.strictEqual(p, p.concat(fulfill()))
+		assert.strictEqual(p, p.or(fulfill()))
 	})
 
 	it('should return other for never', () => {
 		const p1 = never()
 		const p2 = fulfill()
-		assert.strictEqual(p2, p1.concat(p2))
+		assert.strictEqual(p2, p1.or(p2))
 	})
 
 	it('should behave like earlier future', () => {
 		const expected = {}
-		const p = delay(1, expected).concat(delay(10))
+		const p = delay(1, expected).or(delay(10))
 		return assertSame(p, fulfill(expected))
 	})
 
 	it('should behave like other earlier future', () => {
 		const expected = {}
-		const p = delay(10).concat(delay(1, expected))
+		const p = delay(10).or(delay(1, expected))
 		return assertSame(p, fulfill(expected))
 	})
 
 	it('should return other with fulfilled', () => {
 		const expected = {}
 		const p = fulfill(expected)
-		return assert.strictEqual(delay(10).concat(p), p)
+		return assert.strictEqual(delay(10).or(p), p)
 	})
 
 	it('should return other with rejected', () => {
 		const expected = {}
 		const p = reject(expected)
 		silenceError(p)
-		return assert.strictEqual(delay(10).concat(p), p)
+		return assert.strictEqual(delay(10).or(p), p)
 	})
 
 	it('should be identity with never', () => {
 		const p2 = never()
 		const p1 = delay(10)
-		return assert.strictEqual(p1.concat(p2), p1)
+		return assert.strictEqual(p1.or(p2), p1)
 	})
 })


### PR DESCRIPTION
This is a step toward Fantasy Land 2.1.  The idea is to use a different name for the operation currently called concat, since that operation is a race, and as such, is more like Alt than Semigroup.  In 2.0, we can implement a new `concat` that concats two values in the future, rather than racing.  Step 1 in that plan is to provide a new name in the public API for `concat`. I picked `or`.  Fantasy Land calls this operation `alt`, so that may also be a reasonable choice--although I like `or` better for a public API that users will call directly.

### Todo

- [x] Update API docs