### PR TITLE
Add Alt, Plus, Alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "uglify-js": "^2.7.3"
   },
   "dependencies": {
-    "fantasy-land": "^2.0.0"
+    "fantasy-land": "^2.1.0"
   }
 }

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -64,6 +64,14 @@ class Core {
 		return this.concat(p)
 	}
 
+	[fl.alt] (p) {
+		return this.or(p)
+	}
+
+	static [fl.zero] () {
+		return never()
+	}
+
 	// @deprecated The name concat is deprecated, use or() instead.
 	concat (b) {
 		return this.or(b)


### PR DESCRIPTION
Add FL 2.1 implementations and tests: Alt, Plus, Alternative.  The implementations are trivial--they're rally just aliases for `or` and `never`.  This means that for 1.x, Monoid and Alt are basically the same thing.  For 2.0, we can implement a value-based Monoid.

I found that the fantasyland-laws tests were wrong: they were not calling the laws correctly.  The laws are manually curried, and we were calling them with multiple args, so the tests weren't actually verifying anything useful O.o.  Mocha was no help, since it's perfectly content to let you write tests with no assertions even when they return something other than a promise.  That's also why nyc/istanbul wasn't counting coverage: because the tests weren't really calling any creed code.  Fun, eh?