### PR TITLE
Add async traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ ReferenceError: fail is not defined
 
 ## Async traces
 
+**Experimental: V8 only**
+
 Fatal stack traces are helpful, but sometimes they aren't enough.  Enable _async traces_ for stack traces for even more detail.
 
 **Note:** Enabling async traces is typically an application-level concern.  Libraries that use creed *should not* enable them in dist builds.
@@ -182,7 +184,7 @@ Enable async traces by:
 
 ### Performance impact
     
-Async traces have about a 4-5x impact on performance.
+Async traces typically have about a 3-4x impact on performance.
 
 That may be just fine for some applications, while not for others.  Be sure to assess your application performance needs and budget before running with async traces enabled in production.
 
@@ -822,7 +824,7 @@ getReason(never())           //=> throws TypeError
 
 ### enableAsyncTraces :: () &rarr; ()
 
-Enable [async traces](#async-traces).  Should be called as soon after application startup as possible.  Can be called at any time, but will only trace promises created *after* it's called.
+Enable [async traces](#async-traces).  Can be called at any time, but will only trace promises created *after* it's called.  If called multiple times, *resets* the tracing state each time.
 
 ### disableAsyncTraces :: () &rarr; ()
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Fatal stack traces are helpful, but sometimes they aren't enough.  Enable _async
 Running the example above with async traces enabled yields a more helpful trace. Notably:
  
 - asynchronous stack frames are shown: both the point at which map is called and the point in the mapping function (which is called asynchronous) are shown.
-- the Map operation in the example is called out specifically
+- the Map operation is called out specifically
 - stack frames from within creed are omitted
 
 ```
@@ -190,6 +190,8 @@ That may be just fine for some applications, while not for others.  Be sure to a
 
 Creed supports global `window` events in browsers, and `process` events in Node, similar to Node's `'uncaughtException'` event. This allows applications to register a handler to receive events from all promise implementations that support these global events.
 
+Errors passed to unhandled rejection event handlers will have [async traces](#async-traces) if they are enabled.
+
 The events are:
 
 * `'unhandledRejection'`: fired when an unhandled rejection is detected
@@ -201,7 +203,6 @@ The following example shows how to use global `process` events in Node.js to imp
 
 * `reason` - the rejection reason, typically an `Error` instance.
 * `promise` - the promise that was rejected.  This can be used to correlate corresponding `unhandledRejection` and `rejectionHandled` events for the same promise.
-
 
 ```js
 process.on('unhandledRejection', reportRejection)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Enable async traces by:
 
 * `NODE_ENV=development` or `NODE_ENV=test` - async traces will be enabled automatically.
 * `CREED_DEBUG=1` (or any non-empty string) - enables async traces even if NODE_ENV=production or NODE_ENV not set.
-* `enableAsyncTraces()` - programatically enable async traces, e.g. for browsers, etc. where env vars aren't available.
+* [`enableAsyncTraces()`](#enableasynctraces----) - programatically enable async traces, e.g. for browsers, etc. where env vars aren't available.
+    * [`disableAsyncTraces()`](#disableasynctraces----) - programatically disable async traces.
 
 ### Performance impact
     
@@ -820,11 +821,11 @@ getReason(never())           //=> throws TypeError
 
 ### enableAsyncTraces :: () &rarr; ()
 
-Enable [async traces](#asynctraces).  Should be called as soon after application startup as possible.  Can be called at any time, but will only trace promises created *after* it's called.
+Enable [async traces](#async-traces).  Should be called as soon after application startup as possible.  Can be called at any time, but will only trace promises created *after* it's called.
 
 ### disableAsyncTraces :: () &rarr; ()
 
-Disable [async traces](#asynctraces).
+Disable [async traces](#async-traces).
 
 ## Polyfill
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Running the example above with async traces enabled yields a more helpful trace.
 
 ```
 > CREED_DEBUG=1 babel-node experiments/errors.js file1 file2 ...
-/Users/brian/Projects/creed/dist/creed.js:660
-		throw attachTrace(context, value);
+/Users/brian/Projects/creed/dist/creed.js:672
+		throw value;
 		^
 
 ReferenceError: fail is not defined

--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ Running this program (e.g. using `babel-node`) causes a fatal error, exiting the
  
 ```
 > babel-node experiments/errors.js file1 file2 ...
-/Users/brian/Projects/creed/dist/creed.js:660
-		throw attachTrace(context, value);
+/Users/brian/Projects/creed/dist/creed.js:672
+		throw value;
 		^
 
 ReferenceError: fail is not defined
     at append (/Users/brian/Projects/creed/experiments/errors.js:8:39)
     at Array.reduce (native)
     at readFilesP.map.contents (/Users/brian/Projects/creed/experiments/errors.js:13:31)
-    at tryCall (/Users/brian/Projects/creed/dist/creed.js:333:12)
-    at Map.fulfilled (/Users/brian/Projects/creed/dist/creed.js:397:3)
-    at Fulfilled._runAction (/Users/brian/Projects/creed/dist/creed.js:935:10)
-    at Future.run (/Users/brian/Projects/creed/dist/creed.js:861:5)
+    at tryCall (/Users/brian/Projects/creed/dist/creed.js:344:12)
+    at Map.fulfilled (/Users/brian/Projects/creed/dist/creed.js:408:3)
+    at Fulfilled._runAction (/Users/brian/Projects/creed/dist/creed.js:945:10)
+    at Future.run (/Users/brian/Projects/creed/dist/creed.js:871:5)
     at TaskQueue._drain (/Users/brian/Projects/creed/dist/creed.js:131:8)
     at /Users/brian/Projects/creed/dist/creed.js:117:53
     at _combinedTickCallback (internal/process/next_tick.js:67:7)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build-es6": "mkdirp dist && rollup -f cjs -o dist/creed.js src/main.js",
     "build": "npm run build-dist && uglifyjs -c \"warnings=false\" -m -o dist/creed.min.js -- dist/creed.js",
     "preversion": "npm run build",
-    "lint": "jsinspect src && eslint src",
+    "lint": "jsinspect src && eslint src --fix",
     "pretest": "npm run lint",
     "test": "nyc --check-coverage --statements 100 --branches 89 --lines 100 --functions 100 mocha",
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/src/Action.js
+++ b/src/Action.js
@@ -17,8 +17,4 @@ export default class Action {
 		this.promise._become(p)
 		return false
 	}
-
-	toString () {
-		return this.constructor.name
-	}
 }

--- a/src/Action.js
+++ b/src/Action.js
@@ -1,6 +1,9 @@
+import { pushContext } from './trace'
+
 export default class Action {
 	constructor (promise) {
 		this.promise = promise
+		this.context = pushContext(this.constructor)
 	}
 
 	// default onFulfilled action
@@ -13,5 +16,9 @@ export default class Action {
 	rejected (p) {
 		this.promise._become(p)
 		return false
+	}
+
+	toString () {
+		return this.constructor.name
 	}
 }

--- a/src/ErrorHandler.js
+++ b/src/ErrorHandler.js
@@ -1,4 +1,5 @@
 import { silenceError, isHandled } from './inspect'
+import { attachTrace } from './trace'
 
 const UNHANDLED_REJECTION = 'unhandledRejection'
 const HANDLED_REJECTION = 'rejectionHandled'
@@ -11,7 +12,9 @@ export default class ErrorHandler {
 	}
 
 	track (rejected) {
-		if (!this.emit(UNHANDLED_REJECTION, rejected, rejected.value)) {
+		const e = attachTrace(rejected.value, rejected.context)
+
+		if (!this.emit(UNHANDLED_REJECTION, rejected, e)) {
 			/* istanbul ignore else */
 			if (this.rejections.length === 0) {
 				setTimeout(reportErrors, 1, this.reportError, this.rejections)

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -34,6 +34,9 @@ const errorHandler = new ErrorHandler(makeEmitError(), handleError)
 // Internal base type, provides fantasy-land namespace
 // and type representative
 class Core {
+	constructor () {
+		this.context = peekContext()
+	}
 	// empty :: Promise e a
 	static empty () {
 		return never()
@@ -311,7 +314,6 @@ class Rejected extends Core {
 		super()
 		this.value = e
 		this._state = REJECTED
-		this.context = peekContext()
 		errorHandler.track(this)
 	}
 
@@ -472,9 +474,7 @@ export function all (promises) {
 
 const allHandler = {
 	merge (promise, args) {
-		const c = swapContext(this.context)
 		promise._fulfill(args)
-		swapContext(c)
 	}
 }
 

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -14,7 +14,7 @@ import Race from './Race'
 import Merge from './Merge'
 import { resolveIterable, resultsArray } from './iterable'
 
-import { swapContext, peekContext, attachTrace } from './trace'
+import { swapContext, peekContext } from './trace'
 
 import fl from 'fantasy-land'
 
@@ -22,9 +22,7 @@ const taskQueue = new TaskQueue()
 export { taskQueue }
 
 /* istanbul ignore next */
-const handleError = ({ context, value }) => {
-	throw attachTrace(context, value)
-}
+const handleError = ({ value }) => { throw value }
 
 /* istanbul ignore next */
 const errorHandler = new ErrorHandler(makeEmitError(), handleError)

--- a/src/Promise.js
+++ b/src/Promise.js
@@ -21,6 +21,7 @@ import fl from 'fantasy-land'
 const taskQueue = new TaskQueue()
 export { taskQueue }
 
+/* istanbul ignore next */
 const handleError = ({ context, value }) => {
 	throw attachTrace(context, value)
 }

--- a/src/coroutine.js
+++ b/src/coroutine.js
@@ -1,4 +1,5 @@
 import Action from './Action'
+import { pushContext, swapContext } from './trace'
 
 export default function (resolve, iterator, promise) {
 	new Coroutine(resolve, iterator, promise).run()
@@ -17,23 +18,32 @@ class Coroutine extends Action {
 	}
 
 	tryStep (resume, x) {
+		const context = swapContext(this.context)
 		let result
 		// test if `resume` (and only it) throws
 		try {
 			result = resume.call(this.generator, x)
 		} catch (e) {
-			this.promise._reject(e)
+			this.handleReject(context, e)
 			return
 		} // else
-		this.handle(result)
+
+		this.handleResult(context, result)
 	}
 
-	handle (result) {
+	handleResult (context, result) {
 		if (result.done) {
+			swapContext(context)
 			return this.promise._resolve(result.value)
 		}
 
+		this.context = pushContext(this.constructor)
 		this.resolve(result.value)._when(this)
+	}
+
+	handleReject (context, e) {
+		swapContext(context)
+		this.promise._reject(e)
 	}
 
 	fulfilled (ref) {

--- a/src/env.js
+++ b/src/env.js
@@ -7,4 +7,10 @@ const isNode = typeof process !== 'undefined' &&
 const MutationObs = (typeof MutationObserver === 'function' && MutationObserver) ||
     (typeof WebKitMutationObserver === 'function' && WebKitMutationObserver)
 
-export { isNode, MutationObs }
+const getenv = name => isNode && process.env[name]
+
+const isDebug = getenv('CREED_DEBUG') ||
+  getenv('NODE_ENV') === 'development' ||
+  getenv('NODE_ENV') === 'test'
+
+export { isNode, MutationObs, isDebug }

--- a/src/iterable.js
+++ b/src/iterable.js
@@ -59,11 +59,11 @@ function handleItem (resolve, handler, x, i, promise) {
 	} else if (isRejected(p)) {
 		handler.rejectAt(p, i, promise)
 	} else {
-		p._runAction(new Indexed(handler, i, promise))
+		p._runAction(new AtIndex(handler, i, promise))
 	}
 }
 
-class Indexed extends Action {
+class AtIndex extends Action {
 	constructor (handler, i, promise) {
 		super(promise)
 		this.i = i

--- a/src/main.js
+++ b/src/main.js
@@ -14,13 +14,13 @@ import _runNode from './node'
 import _runCoroutine from './coroutine.js'
 
 import { isDebug } from './env'
-import { swapContext, pushContext, enableContextTracing, disableContextTracing } from './trace'
+import { swapContext, pushContext, enableAsyncTraces, disableAsyncTraces } from './trace'
 
-export { enableContextTracing, disableContextTracing }
+export { enableAsyncTraces, disableAsyncTraces }
 
 /* istanbul ignore next */
 if (isDebug) {
-	enableContextTracing()
+	enableAsyncTraces()
 }
 
 // -------------------------------------------------------------

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,15 @@ import _runPromise from './runPromise'
 import _runNode from './node'
 import _runCoroutine from './coroutine.js'
 
+import { isDebug } from './env'
+import { swapContext, pushContext, enableContextTracing, disableContextTracing } from './trace'
+
+export { enableContextTracing, disableContextTracing }
+
+if (isDebug) {
+	enableContextTracing()
+}
+
 // -------------------------------------------------------------
 // ## Core promise methods
 // -------------------------------------------------------------
@@ -134,6 +143,7 @@ function runMerge (f, thisArg, args) {
 
 class MergeHandler {
 	constructor (f, c) {
+		this.context = pushContext(this.constructor, Merge.name)
 		this.f = f
 		this.c = c
 		this.promise = void 0
@@ -147,11 +157,13 @@ class MergeHandler {
 	}
 
 	run () {
+		const c = swapContext(this.context)
 		try {
 			this.promise._resolve(this.f.apply(this.c, this.args))
 		} catch (e) {
 			this.promise._reject(e)
 		}
+		swapContext(c)
 	}
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import { swapContext, pushContext, enableContextTracing, disableContextTracing }
 
 export { enableContextTracing, disableContextTracing }
 
+/* istanbul ignore next */
 if (isDebug) {
 	enableContextTracing()
 }

--- a/src/node.js
+++ b/src/node.js
@@ -1,11 +1,17 @@
+import { pushContext, swapContext } from './trace'
+
 export default function runNode (f, thisArg, args, promise) {
-	/* eslint complexity:[2,5] */
+	const context = pushContext(f)
+
+  /* eslint complexity:[2,5] */
 	function settleNode (e, x) {
+		const c = swapContext(context)
 		if (e) {
 			promise._reject(e)
 		} else {
 			promise._fulfill(x)
 		}
+		swapContext(c)
 	}
 
 	switch (args.length) {

--- a/src/node.js
+++ b/src/node.js
@@ -1,11 +1,9 @@
-import { pushContext, swapContext } from './trace'
+import { swapContext } from './trace'
 
 export default function runNode (f, thisArg, args, promise) {
-	const context = pushContext(f)
-
   /* eslint complexity:[2,5] */
 	function settleNode (e, x) {
-		const c = swapContext(context)
+		const c = swapContext(promise.context)
 		if (e) {
 			promise._reject(e)
 		} else {

--- a/src/runPromise.js
+++ b/src/runPromise.js
@@ -1,11 +1,19 @@
+import { pushContext, swapContext } from './trace'
+
 export default function runPromise (f, thisArg, args, promise) {
-	/* eslint complexity:[2,5] */
+	const context = pushContext(f)
+
+  /* eslint complexity:[2,5] */
 	function resolve (x) {
+		const c = swapContext(context)
 		promise._resolve(x)
+		swapContext(c)
 	}
 
 	function reject (e) {
+		const c = swapContext(context)
 		promise._reject(e)
+		swapContext(c)
 	}
 
 	switch (args.length) {

--- a/src/runPromise.js
+++ b/src/runPromise.js
@@ -1,17 +1,15 @@
-import { pushContext, swapContext } from './trace'
+import { swapContext } from './trace'
 
 export default function runPromise (f, thisArg, args, promise) {
-	const context = pushContext(f)
-
   /* eslint complexity:[2,5] */
 	function resolve (x) {
-		const c = swapContext(context)
+		const c = swapContext(promise.context)
 		promise._resolve(x)
 		swapContext(c)
 	}
 
 	function reject (e) {
-		const c = swapContext(context)
+		const c = swapContext(promise.context)
 		promise._reject(e)
 		swapContext(c)
 	}

--- a/src/trace.js
+++ b/src/trace.js
@@ -27,18 +27,18 @@ export const swapContext = context => {
 // return a new current context
 // initialContext :: c
 // An initial current context
-export const traceContext = (createContext, initialContext) => {
+export const traceAsync = (createContext, initialContext) => {
 	_createContext = createContext
 	_currentContext = initialContext
 }
 
 // Enable default context tracing
-export const enableContextTracing = () =>
-	traceContext(createContext, undefined)
+export const enableAsyncTraces = () =>
+	traceAsync(createContext, undefined)
 
 // Disable context tracing
-export const disableContextTracing = () =>
-  traceContext(noop, undefined)
+export const disableAsyncTraces = () =>
+  traceAsync(noop, undefined)
 
 // ------------------------------------------------------
 // Default context tracing

--- a/src/trace.js
+++ b/src/trace.js
@@ -28,8 +28,8 @@ export const swapContext = context => {
 // initialContext :: c
 // An initial current context
 export const traceContext = (createContext, initialContext) => {
-	_currentContext = initialContext
 	_createContext = createContext
+	_currentContext = initialContext
 }
 
 // Enable default context tracing
@@ -39,29 +39,6 @@ export const enableContextTracing = () =>
 // Disable context tracing
 export const disableContextTracing = () =>
   traceContext(noop, undefined)
-
-// ------------------------------------------------------
-// Formatting
-
-export const attachTrace = (context, e) => {
-	if (context !== undefined) {
-		e.stack = elideTrace(e.stack) + formatTrace(context)
-	}
-
-	return e
-}
-
-export const formatTrace = context =>
-  context === undefined ? ''
-    : elideTrace(context.stack) + formatTrace(context.next)
-
-export const elideTraceRx =
-  /\s*at\s.*(creed[\\/](src|dist)[\\/]|internal[\\/]process[\\/]|\((timers|module)\.js).+:\d.*/g
-
-export const elideTrace = stack => {
-	const s = stack.replace(elideTraceRx, '')
-	return s.indexOf(' at ') < 0 ? '' : '\n' + s
-}
 
 // ------------------------------------------------------
 // Default context tracing
@@ -81,4 +58,27 @@ export class Context {
 	toString () {
 		return this.tag ? ` from ${this.tag}:` : ' from previous context:'
 	}
+}
+
+// ------------------------------------------------------
+// Default context formatting
+
+export const attachTrace = (context, e) => {
+	if (context !== undefined) {
+		e.stack = elideTrace(e.stack) + formatTrace(context)
+	}
+
+	return e
+}
+
+export const formatTrace = context =>
+  context === undefined ? ''
+    : elideTrace(context.stack) + formatTrace(context.next)
+
+export const elideTraceRx =
+  /\s*at\s.*(creed[\\/](src|dist)[\\/]|internal[\\/]process[\\/]|\((timers|module)\.js).+:\d.*/g
+
+export const elideTrace = stack => {
+	const s = stack.replace(elideTraceRx, '')
+	return s.indexOf(' at ') < 0 ? '' : '\n' + s
 }

--- a/src/trace.js
+++ b/src/trace.js
@@ -45,7 +45,7 @@ export const disableContextTracing = () =>
 
 export const attachTrace = (context, e) => {
 	if (context !== undefined) {
-		e.stack = elide(e.stack) + formatTrace(context)
+		e.stack = elideTrace(e.stack) + formatTrace(context)
 	}
 
 	return e
@@ -53,25 +53,25 @@ export const attachTrace = (context, e) => {
 
 export const formatTrace = context =>
   context === undefined ? ''
-    : elide(context.stack) + formatTrace(context.next)
+    : elideTrace(context.stack) + formatTrace(context.next)
 
-const defaultStackRx =
+export const elideTraceRx =
   /\s*at\s.*(creed[\\/](src|dist)[\\/]|internal[\\/]process[\\/]|\((timers|module)\.js).+:\d.*/g
 
-const elide = stack => {
-	const s = stack.replace(defaultStackRx, '')
+export const elideTrace = stack => {
+	const s = stack.replace(elideTraceRx, '')
 	return s.indexOf(' at ') < 0 ? '' : '\n' + s
 }
 
 // ------------------------------------------------------
 // Default context tracing
 
-const createContext = (currentContext, at, tag) =>
+export const createContext = (currentContext, at, tag) =>
   new Context(currentContext, tag || at.name, at)
 
-const captureStackTrace = Error.captureStackTrace || noop
+export const captureStackTrace = Error.captureStackTrace || noop
 
-class Context {
+export class Context {
 	constructor (next, tag, at) {
 		this.next = next
 		this.tag = tag

--- a/src/trace.js
+++ b/src/trace.js
@@ -1,0 +1,84 @@
+const noop = () => {}
+
+// WARNING: shared mutable notion of "current context"
+let _currentContext
+let _createContext = noop
+
+// Get the current context
+export const peekContext = () => _currentContext
+
+// Append a new context to the current, and set the current context
+// to the newly appended one
+export const pushContext = (at, tag) =>
+	_createContext(_currentContext, at, tag)
+
+// Set the current context to the provided one, returning the
+// previously current context (which makes it easy to swap back
+// to it)
+export const swapContext = context => {
+	const previousContext = _currentContext
+	_currentContext = context
+	return previousContext
+}
+
+// Enable context tracing.  Must provide:
+// createContext :: c -> Function -> String -> c
+// Given the current context, and a function and string tag representing a new context,
+// return a new current context
+// initialContext :: c
+// An initial current context
+export const traceContext = (createContext, initialContext) => {
+	_currentContext = initialContext
+	_createContext = createContext
+}
+
+// Enable default context tracing
+export const enableContextTracing = () =>
+	traceContext(createContext, undefined)
+
+// Disable context tracing
+export const disableContextTracing = () =>
+  traceContext(noop, undefined)
+
+// ------------------------------------------------------
+// Formatting
+
+export const attachTrace = (context, e) => {
+	if (context !== undefined) {
+		e.stack = elide(e.stack) + formatTrace(context)
+	}
+
+	return e
+}
+
+export const formatTrace = context =>
+  context === undefined ? ''
+    : elide(context.stack) + formatTrace(context.next)
+
+const defaultStackRx =
+  /\s*at\s.*(creed[\\/](src|dist)[\\/]|internal[\\/]process[\\/]|\((timers|module)\.js).+:\d.*/g
+
+const elide = stack => {
+	const s = stack.replace(defaultStackRx, '')
+	return s.indexOf(' at ') < 0 ? '' : '\n' + s
+}
+
+// ------------------------------------------------------
+// Default context tracing
+
+const createContext = (currentContext, at, tag) =>
+  new Context(currentContext, tag || at.name, at)
+
+const captureStackTrace = Error.captureStackTrace || noop
+
+class Context {
+	constructor (next, tag, at) {
+		this.next = next
+		this.tag = tag
+		captureStackTrace(this, at)
+	}
+
+	toString () {
+		return this.tag ? ` from ${this.tag}:` : ' from previous context:'
+	}
+}

--- a/test/Action-test.js
+++ b/test/Action-test.js
@@ -45,10 +45,4 @@ describe('Action', () => {
       is(expected, promise.actual)
     })
   })
-
-  describe('toString', () => {
-    it('should be constructor name', () => {
-      eq(Action.name, new Action({}).toString())
-    })
-  })
 })

--- a/test/Action-test.js
+++ b/test/Action-test.js
@@ -1,0 +1,54 @@
+import { describe, it } from 'mocha'
+import { eq, is, assert } from '@briancavalier/assert'
+
+import Action from '../src/Action'
+
+describe('Action', () => {
+  it('should have expected promise and context', () => {
+    const promise = {}
+    const action = new Action(promise)
+
+    is(promise, action.promise)
+    assert('context' in action)
+  })
+
+  describe('fulfilled', () => {
+    it('should make promise become incoming fulfilled promise', () => {
+      const expected = {}
+      const promise = {
+        actual: undefined,
+        _become (p) {
+          this.actual = p
+        }
+      }
+
+      const action = new Action(promise)
+      action.fulfilled(expected)
+
+      is(expected, promise.actual)
+    })
+  })
+
+  describe('rejected', () => {
+    it('should make promise become incoming rejected promise', () => {
+      const expected = {}
+      const promise = {
+        actual: undefined,
+        _become (p) {
+          this.actual = p
+        }
+      }
+
+      const action = new Action(promise)
+      action.rejected(expected)
+
+      is(expected, promise.actual)
+    })
+  })
+
+  describe('toString', () => {
+    it('should be constructor name', () => {
+      eq(Action.name, new Action({}).toString())
+    })
+  })
+})

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -1,12 +1,12 @@
 import { describe, it, afterEach } from 'mocha'
 import { is, eq, assert, fail } from '@briancavalier/assert'
 
-import { traceContext, pushContext, swapContext, peekContext, formatTrace, attachTrace, captureStackTrace,
-createContext, elideTrace, enableContextTracing, disableContextTracing, Context
+import { traceAsync, pushContext, swapContext, peekContext, formatTrace, attachTrace, captureStackTrace,
+createContext, elideTrace, enableAsyncTraces, disableAsyncTraces, Context
 } from '../src/trace'
 
 describe('trace', () => {
-  afterEach(() => disableContextTracing())
+  afterEach(() => disableAsyncTraces())
 
   describe('pushContext', () => {
     it('should return expected context', () => {
@@ -15,7 +15,7 @@ describe('trace', () => {
       const at = () => {}
       const tag = `${Math.random()}`
 
-      traceContext(createContext, initialContext)
+      traceAsync(createContext, initialContext)
       const actual = pushContext(at, tag)
 
       is(initialContext, actual.context)
@@ -31,7 +31,7 @@ describe('trace', () => {
       const at = () => {}
       const tag = `${Math.random()}`
 
-      traceContext(createContext, initialContext)
+      traceAsync(createContext, initialContext)
 
       const context1 = pushContext(at, tag)
 
@@ -51,7 +51,7 @@ describe('trace', () => {
       const initialContext = {}
       const otherContext = {}
 
-      traceContext(createContext, initialContext)
+      traceAsync(createContext, initialContext)
 
       is(initialContext, peekContext())
 
@@ -61,9 +61,9 @@ describe('trace', () => {
     })
   })
 
-  describe('enableContextTracing', () => {
+  describe('enableAsyncTraces', () => {
     it('should install default initialContext and createContext', () => {
-      enableContextTracing()
+      enableAsyncTraces()
 
       const context = pushContext(() => {}, '')
 
@@ -73,11 +73,11 @@ describe('trace', () => {
     })
   })
 
-  describe('disableContextTracing', () => {
+  describe('disableAsyncTraces', () => {
     it('should remove context and default createContext', () => {
       const initialContext = {}
-      traceContext(fail, initialContext)
-      disableContextTracing()
+      traceAsync(fail, initialContext)
+      disableAsyncTraces()
 
       eq(undefined, pushContext(() => {}, ''))
       eq(undefined, swapContext({}))

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'mocha'
+import { traceContext, pushContext, swapContext, peekContext, formatTrace, attachTrace } from '../src/trace'
+import { is, eq, assert } from '@briancavalier/assert'
+
+describe('trace', () => {
+  describe('pushContext', () => {
+    it('should return expected context', () => {
+      const createContext = (context, at, tag) => ({ context, at, tag })
+      const initialContext = {}
+      const at = () => {}
+      const tag = `${Math.random()}`
+
+      traceContext(createContext, initialContext)
+      const actual = pushContext(at, tag)
+
+      is(initialContext, actual.context)
+      is(at, actual.at)
+      eq(tag, actual.tag)
+    })
+  })
+
+  describe('swapContext', () => {
+    it('should return expected context', () => {
+      const createContext = (context, at, tag) => ({ context, at, tag })
+      const initialContext = {}
+      const at = () => {}
+      const tag = `${Math.random()}`
+
+      traceContext(createContext, initialContext)
+
+      const context1 = pushContext(at, tag)
+
+      const context0 = swapContext(context1)
+
+      is(initialContext, context0)
+
+      const actual = swapContext(context0)
+
+      is(context1, actual)
+    })
+  })
+
+  describe('peekContext', () => {
+    it('should return current context', () => {
+      const createContext = () => {}
+      const initialContext = {}
+      const otherContext = {}
+
+      traceContext(createContext, initialContext)
+
+      is(initialContext, peekContext())
+
+      swapContext(otherContext)
+
+      is(otherContext, peekContext())
+    })
+  })
+
+  describe('enableContextTracing', () => {
+
+  })
+
+  describe('disableContextTracing', () => {
+
+  })
+
+  describe('attachTrace', () => {
+    it('should not modify stack when context is undefined', () => {
+      const expected = new Error()
+      const expectedStack = expected.stack
+      const actual = attachTrace(undefined, expected)
+
+      is(expected, actual)
+      eq(expectedStack, actual.stack)
+    })
+
+    it('should modify stack when context is provided', () => {
+      const expected = new Error()
+      const unexpectedStack = expected.stack
+      const context = new Error()
+
+      const actual = attachTrace(context, expected)
+
+      is(expected, actual)
+      assert(unexpectedStack !== actual.stack)
+    })
+  })
+
+  describe('formatTrace', () => {
+    it('should return empty string for missing context', () => {
+      eq('', formatTrace(undefined))
+    })
+
+    it('should retain expected frames from all contexts', () => {
+
+    })
+  })
+
+  describe('elideTrace', () => {
+    it('should retain only expected frames', () => {
+
+    })
+    it('should return empty when all frames elided', () => {
+
+    })
+  })
+})

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -1,7 +1,7 @@
 import { describe, it, afterEach } from 'mocha'
 import { is, eq, assert, fail } from '@briancavalier/assert'
 
-import { traceAsync, pushContext, swapContext, peekContext, formatTrace, attachTrace, captureStackTrace,
+import { traceAsync, pushContext, swapContext, peekContext, formatContext, attachTrace, captureStackTrace,
 createContext, elideTrace, enableAsyncTraces, disableAsyncTraces, Context
 } from '../src/trace'
 
@@ -88,7 +88,7 @@ describe('trace', () => {
     it('should not modify stack when context is undefined', () => {
       const expected = new Error()
       const expectedStack = expected.stack
-      const actual = attachTrace(undefined, expected)
+      const actual = attachTrace(expected, undefined)
 
       is(expected, actual)
       eq(expectedStack, actual.stack)
@@ -99,16 +99,17 @@ describe('trace', () => {
       const unexpectedStack = expected.stack
       const context = new Error()
 
-      const actual = attachTrace(context, expected)
+      const actual = attachTrace(expected, context)
 
       is(expected, actual)
       assert(unexpectedStack !== actual.stack)
     })
   })
 
-  describe('formatTrace', () => {
-    it('should return empty string for missing context', () => {
-      eq('', formatTrace(undefined))
+  describe('formatContext', () => {
+    it('should return initial for missing context', () => {
+      const initial = `${Math.random()}`
+      eq(initial, formatContext(initial, undefined))
     })
 
     it('should retain expected frames from all contexts', () => {
@@ -131,20 +132,23 @@ describe('trace', () => {
       const context1 = { stack: trace1, next: undefined }
       const context2 = { stack: trace2, next: context1 }
 
-      const expected = '\nTrace 2:\n'
+      const initial = `${Math.random()}`
+      const expected = initial
+        + '\nTrace 2:\n'
         + ' at c\n'
         + ' at d\n'
         + 'Trace 1:\n'
         + ' at a\n'
         + ' at b'
 
-      eq(expected, formatTrace(context2))
+      eq(expected, formatContext(initial, context2))
     })
   })
 
   describe('elideTrace', () => {
     it('should retain only expected frames', () => {
-      const trace = 'Test\n'
+      const initial = `${Math.random()}\n`
+      const trace = initial
         + ' at a\n'
         + ' at (creed/src/):1:1\n'
         + ' at (creed\\src\\):1:2\n'
@@ -158,11 +162,12 @@ describe('trace', () => {
         + ' at (timers.js):4:1\n'
         + ' at (module.js):4:2\n'
 
-      eq('\nTest\n at a\n at b\n at c\n at d\n', elideTrace(trace))
+      eq(initial + ' at a\n at b\n at c\n at d\n', elideTrace(trace))
     })
 
     it('should return empty when all frames elided', () => {
-      const trace = 'Test\n'
+      const initial = `${Math.random()}\n`
+      const trace = initial
         + ' at (creed/src/):1:1\n'
         + ' at (creed\\src\\):1:2\n'
         + ' at (creed/dist/):2:1\n'
@@ -172,7 +177,7 @@ describe('trace', () => {
         + ' at (timers.js):4:1\n'
         + ' at (module.js):4:2\n'
 
-      eq('', elideTrace(trace))
+      eq(initial, elideTrace(trace))
     })
   })
 


### PR DESCRIPTION
Add async traces (aka "long stack traces").  Uncaught errors will have an async stack trace attached.  It uses a singleton stack (linked list) to track the current context.  There is little to no perf impact when tracing is disabled.  There is a *reasonable* (imho!) performance cost when tracing is enabled: about 3-4x cpu hit on node 6, which seems completely worth it when you need it!

### New Internal APIs

- `pushContext` pushes a context onto the context stack
- `swapContext` swaps in a new context stack, returning the previously-current one.  This allows swapping in a new current context before running user code, and then swapping back to the previous one when the user code is done.
- `peekContext` return the current context stack
- A few others dealing with stack trace filtering and formatting.  See the code.

### New Public APIs

- `enableAsyncTraces()` turns on tracing
- `disableAsyncTraces()` turns off tracing (and drops whatever the current context stack holds)
- `NODE_ENV` env var set to `"development"` or `"test"` will enable tracing
- `CREED_DEBUG` env var set to any non-empty value will enable tracing.  This allows forcing async traces to be enabled in production (when `NODE_ENV=production`, for example)

### Todo

- [x] Update README to include API for enabling/disabling (including `NODE_ENV` and `CREED_DEBUG` env vars)