### PR TITLE
fix(trace): Defend against Errors with missing or bogus stacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,15 @@
     "async"
   ],
   "scripts": {
-    "build-dist": "mkdirp dist && rollup -c",
-    "build-es6": "mkdirp dist && rollup -f cjs -o dist/creed.js src/main.js",
-    "build": "npm run build-dist && uglifyjs -c \"warnings=false\" -m -o dist/creed.min.js -- dist/creed.js",
+    "build": "npm run build:dist && npm run build:min",
+    "build:dist": "mkdirp dist && rollup -c",
+    "build:min": "uglifyjs -c \"warnings=false\" -m -o dist/creed.min.js -- dist/creed.js",
     "preversion": "npm run build",
-    "lint": "jsinspect src && eslint src --fix",
-    "pretest": "npm run lint",
-    "test": "nyc --check-coverage --statements 100 --branches 89 --lines 100 --functions 100 mocha",
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "posttest": "npm run test-aplus",
-    "test-aplus": "promises-aplus-tests test/aplus.js --reporter dot"
+    "test": "npm run test:lint && npm run test:unit && npm run test:aplus",
+    "test:lint": "jsinspect src && eslint src --fix",
+    "test:unit": "nyc --check-coverage --statements 100 --branches 89 --lines 100 --functions 100 mocha",
+    "test:aplus": "promises-aplus-tests test/aplus.js --reporter dot",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "devDependencies": {
     "@briancavalier/assert": "^3.4.0",

--- a/src/trace.js
+++ b/src/trace.js
@@ -63,15 +63,16 @@ export class Context {
 // ------------------------------------------------------
 // Default context formatting
 
-// If e is an Error, attach an async trace for the provided context.
+// If context provided, attach an async trace for it.
 // Otherwise, do nothing.
 export const attachTrace = (e, context) =>
-  context != null && e instanceof Error ? formatTrace(e, context) : e
+  context != null ? formatTrace(e, context) : e
 
-// Attach an async trace to e for the provided context
-function formatTrace (e, context) {
-	if (!e._creedOriginalStack) {
-		e._creedOriginalStack = e.stack
+// If e is an Error, attach an async trace to e for the provided context
+// Otherwise, do nothing
+export function formatTrace (e, context) {
+	if (e instanceof Error && !('_creed$OriginalStack' in e)) {
+		e._creed$OriginalStack = e.stack
 		e.stack = formatContext(elideTrace(e.stack), context)
 	}
 	return e
@@ -91,4 +92,4 @@ export const elideTraceRx =
 
 // Remove internal stack frames
 export const elideTrace = stack =>
-	stack.replace(elideTraceRx, '')
+	typeof stack === 'string' ? stack.replace(elideTraceRx, '') : ''


### PR DESCRIPTION
Defend against Errors with missing or bogus stacks.  Error instances or subclasses with missing or non-string stacks would crash async trace reconstruction because of a blind call to `stack.replace`.

Also, refactored npm scripts a bit to make it easier to run just unit tests (`npm run test:unit`) for faster iteration while developing.