### PR TITLE
test(toString): add toString resolution tests

### DIFF
--- a/test/ErrorHandler-test.js
+++ b/test/ErrorHandler-test.js
@@ -1,22 +1,15 @@
 import { describe, it } from 'mocha'
-import ErrorHandler from '../src/ErrorHandler'
-import { is, eq, fail } from '@briancavalier/assert'
-import { HANDLED } from '../src/state'
+import { eq, fail, is } from '@briancavalier/assert'
 
-function fakeError (value) {
-  return {
-    value: value,
-    _state: 0,
-    state () { return this._state },
-    _runAction () { this._state |= HANDLED }
-  }
-}
+import ErrorHandler from '../src/ErrorHandler'
+import { HANDLED } from '../src/state'
+import { reject } from '../src/Promise'
 
 describe('ErrorHandler', () => {
   describe('track', () => {
     it('should emit event immediately', () => {
       const value = {}
-      const expected = fakeError(value)
+      const expected = reject(value)
 
       function verify (event, e, error) {
         is(e, expected)
@@ -30,7 +23,7 @@ describe('ErrorHandler', () => {
 
     it('should report error later', done => {
       const value = {}
-      const expected = fakeError(value)
+      const expected = reject(value)
       function verify (e) {
         is(e, expected)
         is(e.value, value)
@@ -45,7 +38,7 @@ describe('ErrorHandler', () => {
   describe('untrack', () => {
     it('should emit event immediately', () => {
       const value = {}
-      const expected = fakeError(value)
+      const expected = reject(value)
 
       function verify (event, e) {
         is(e, expected)
@@ -59,12 +52,12 @@ describe('ErrorHandler', () => {
 
     it('should silence error', () => {
       const value = {}
-      const expected = fakeError(value)
+      const expected = reject(value)
 
       const eh = new ErrorHandler(() => true, fail)
       eh.untrack(expected)
 
-      eq(expected.state(), HANDLED)
+      eq(expected.state() & HANDLED, HANDLED)
     })
   })
 })

--- a/test/toString-test.js
+++ b/test/toString-test.js
@@ -1,28 +1,43 @@
+import { Future, fulfill, future, never, reject } from '../src/Promise'
 import { describe, it } from 'mocha'
-import { fulfill, reject, Future, never } from '../src/Promise'
-import { getValue, getReason } from '../src/inspect'
+import { getReason, getValue } from '../src/inspect'
+
 import { eq } from '@briancavalier/assert'
+
+const verifyToStringResolved = (resolution) => {
+  const { resolve, promise } = future()
+  resolve(resolution)
+  eq(resolution.toString(), promise.toString())
+}
 
 describe('toString', () => {
   it('should indicate fulfilled promise', () => {
-    let p = fulfill('a')
+    const p = fulfill('a')
     eq(`[object Promise { fulfilled: ${getValue(p)} }]`,
             p.toString())
   })
 
   it('should indicate rejected promise', () => {
-    let p = reject(new Error('a'))
+    const p = reject(new Error('a'))
     eq(`[object Promise { rejected: ${getReason(p)} }]`,
             p.toString())
   })
 
   it('should indicate pending promise', () => {
-    let p = new Future()
+    const p = new Future()
     eq('[object Promise { pending }]', p.toString())
   })
 
+  it('should indicate resolution for promise resolved to fulfilled', () => {
+    verifyToStringResolved(fulfill('a'))
+  })
+
+  it('should indicate resolution for promise resolved to fulfilled', () => {
+    verifyToStringResolved(reject(new Error('a')))
+  })
+
   it('should indicate never', () => {
-    let p = never()
+    const p = never()
     eq('[object Promise { never }]', p.toString())
   })
 })


### PR DESCRIPTION
Add tests for toString to cover the case where a future promise is resolved to a settled one.