### PR TITLE
Simplify and improve trace output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 env:
   - CXX=g++-4.8
 node_js:
-  - '7'
+  - '9'
+  - '8'
   - '6'
 branches:
   only:

--- a/src/trace.js
+++ b/src/trace.js
@@ -52,11 +52,8 @@ export class Context {
   constructor (next, tag, at) {
     this.next = next
     this.tag = tag
+    this.name = tag ? ` from ${tag}:` : ' from previous context:'
     captureStackTrace(this, at)
-  }
-
-  toString () {
-    return this.tag ? ` from ${this.tag}:` : ' from previous context:'
   }
 }
 
@@ -88,7 +85,7 @@ export function formatContext (trace, context) {
 }
 
 export const elideTraceRx =
-  /\s*at\s.*(creed[\\/](src|dist)[\\/]|internal[\\/]process[\\/]|\((timers|module)\.js).+:\d.*/g
+  /\s*at\s.*(creed[\\/](src|dist)[\\/]|\([^\\/]+\.js).+:\d.*/g
 
 // Remove internal stack frames
 export const elideTrace = stack =>

--- a/src/trace.js
+++ b/src/trace.js
@@ -55,6 +55,10 @@ export class Context {
     this.name = tag ? ` from ${tag}:` : ' from previous context:'
     captureStackTrace(this, at)
   }
+
+  toString () {
+    return this.name
+  }
 }
 
 // ------------------------------------------------------
@@ -85,7 +89,7 @@ export function formatContext (trace, context) {
 }
 
 export const elideTraceRx =
-  /\s*at\s.*(creed[\\/](src|dist)[\\/]|\([^\\/]+\.js).+:\d.*/g
+  /\s*at\s.*(creed[\\/](src|dist)[\\/]|\((\w+|internal[\\/].+\.js)).+:\d.*/g
 
 // Remove internal stack frames
 export const elideTrace = stack =>

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -250,6 +250,7 @@ describe('trace', () => {
 
       const actual = new Context(next, tag, at)
       assert(actual.name.indexOf(tag) >= 0)
+      assert(actual.toString().indexOf(tag) >= 0)
     })
 
     it('should have default name when tag missing', () => {
@@ -260,6 +261,7 @@ describe('trace', () => {
       const actual = new Context(next, tag, at)
 
       assert(actual.name.length > 0)
+      assert(actual.toString().length > 0)
     })
   })
 

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -243,23 +243,23 @@ describe('trace', () => {
       eq(tag, actual.tag)
     })
 
-    it('should have toString containing tag when tag present', () => {
+    it('should have name containing tag when tag present', () => {
       const next = {}
       const at = () => {}
       const tag = `${Math.random()}`
 
       const actual = new Context(next, tag, at)
-      assert(actual.toString().indexOf(tag) >= 0)
+      assert(actual.name.indexOf(tag) >= 0)
     })
 
-    it('should have default toString when tag missing', () => {
+    it('should have default name when tag missing', () => {
       const next = {}
       const at = () => {}
       const tag = ''
 
       const actual = new Context(next, tag, at)
 
-      assert(actual.toString().length > 0)
+      assert(actual.name.length > 0)
     })
   })
 


### PR DESCRIPTION
Trace eliding and naming was not working well in Node 6-9, due to what appears to be some changes in how captureStackTrace generates the first line of the trace.  Also, internal file names seem to change between every Node release, so trying to elide them by listing a few names isn't really a sustainable solution.  It looks like the internal filenames are always like `just_a_filename.js`, with no preceding path (and specifically, no slashes).  So, this switches to a regex that filters out lines that point at `just_a_filename.js`.