### PR TITLE
fix(readme): change to babel-node-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,18 @@ Note that although babel supports ES2015 `import` statements, [the `babel-node` 
 
 ```
 npm install creed
-npm install -g babel-node-cli
-babel-node
+node
 > let { resolve, delay, all, race } = require('creed')
-'use strict'
+undefined
 > resolve('hello')
 Promise { fulfilled: hello }
 > all([1, 2, 3].map(resolve))
 Promise { fulfilled: 1,2,3 }
 > let p = delay(1000, 'done!'); p
 Promise { pending }
+
 ... wait 1 second ...
+
 > p
 Promise { fulfilled: done! }
 > race([delay(100, 'no'), 'winner'])

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Note that although babel supports ES2015 `import` statements, [the `babel-node` 
 
 ```
 npm install creed
-npm install -g babel-node
+npm install -g babel-node-cli
 babel-node
 > let { resolve, delay, all, race } = require('creed')
 'use strict'


### PR DESCRIPTION
Update the package name, the old one throws the warning:
```sh
You tried to install babel-node. This is not babel-node 🚫          │
|               You should npm install -g babel-cli instead 💁 .               │
|    I took this module to prevent somebody from pushing malicious code. 🕵    │
|                    Be careful out there,
```